### PR TITLE
Update URLs of SK-archives

### DIFF
--- a/docs/_archives/recipes/scripts/get_slakos
+++ b/docs/_archives/recipes/scripts/get_slakos
@@ -6,28 +6,31 @@ scriptdir="$(dirname $0)"
 root="$scriptdir/.."
 downloaddir="$root/slakos/download"
 downloadfile="$root/slakos/SLAKO_DOWNLOADS"
-slakourlprefix="http://www.dftb.org/fileadmin/DFTB/public/slako"
+slakourlprefix="https://github.com/dftbparams"
 
-echo "Downloading SLAKO archives:"
+echo "Downloading Slater-Koster archives:"
 for remotefile in $(cat $downloadfile); do
   destdir=$(dirname $remotefile)
+  skshortname=${destdir%%/*}
   fname=$(basename $remotefile)
   mkdir -p $downloaddir/$destdir
-  
+
   echo "Downloading $remotefile"
   echo "wget -q -O $downloaddir/$destdir/$fname $slakourlprefix/$remotefile"
   wget -q -O $downloaddir/$destdir/$fname $slakourlprefix/$remotefile
   if [ $? -ne 0 ]; then
-    echo "DOWNLOAD FAILED for$ slakourlprefix/$remotefile" >&2
+    echo "DOWNLOAD FAILED for $slakourlprefix/$remotefile" >&2
   fi
 
   if [ "$(basename $fname .tar.xz)" != "$fname" ]; then
     echo "Unpacking archive $fname"
-    tar -x -C $downloaddir/$destdir -J -f $downloaddir/$destdir/$fname
+    tar -x -C $downloaddir/$skshortname -J -f $downloaddir/$destdir/$fname
     if [ $? -ne 0 ]; then
       echo "UNPACKING FAILED for $downloaddir/$destdir/$fname" >&2
     fi
     echo "Removing archive $fname"
     rm -f $downloaddir/$destdir/$fname
+    echo "Removing temporary (empty) folders"
+    find $downloaddir/$skshortname -type d -empty -delete
   fi
 done

--- a/docs/_archives/recipes/slakos/SLAKO_DOWNLOADS
+++ b/docs/_archives/recipes/slakos/SLAKO_DOWNLOADS
@@ -1,7 +1,7 @@
-3ob/3ob-3-1.tar.xz
-mio/mio-1-1.tar.xz
-mio/wfc.mio-1-1.hsd
-tiorg/tiorg-0-1.tar.xz
-ob2/ob2-1-1.tar.xz
-siband/siband-1-1.tar.xz
-siband/wfc.siband-1-1.hsd
+3ob/releases/download/v3.1.0/3ob-3-1.tar.xz
+mio/releases/download/v1.1.0/mio-1-1.tar.xz
+mio/releases/download/v1.1.0/mio-1-1-extras.tar.xz
+tiorg/releases/download/v0.1.0/tiorg-0-1.tar.xz
+ob2/releases/download/v1.1.0/ob2-1-1.tar.xz
+siband/releases/download/v1.1.0/siband-1-1.tar.xz
+siband/releases/download/v1.1.0/siband-1-1-extras.tar.xz

--- a/docs/_archives/recipes/slakos/wfc/wfc.mio-1-1.hsd
+++ b/docs/_archives/recipes/slakos/wfc/wfc.mio-1-1.hsd
@@ -1,1 +1,1 @@
-../download/mio/wfc.mio-1-1.hsd
+../download/mio/mio-1-1-extras/wfc.hsd


### PR DESCRIPTION
Closes https://github.com/dftbplus/dftbplus/issues/1639.

@bhourahine This still leaves empty temporary subdirectories, e.g. `$skshortname/releases/download/v3.1.0`, in place. I was a bit reluctant to use a `rm -rf` construct in this script.